### PR TITLE
Remove `rotate_from_matrix`

### DIFF
--- a/diffsims/crystallography/reciprocal_lattice_vector.py
+++ b/diffsims/crystallography/reciprocal_lattice_vector.py
@@ -503,21 +503,6 @@ class ReciprocalLatticeVector(Vector3d):
 
         return 0.5 * self.gspacing
 
-    def rotate_from_matrix(self, rotation_matrix):
-        """Rotate the reciprocal lattice vectors using a (3x3) rotation matrix.
-
-        This method creates a new instance of :class:`ReciprocalLatticeVector`
-        with the rotated vectors.
-
-        Parameters
-        ----------
-        rotation_matrix : numpy.ndarray
-            (3, 3) rotation matrix.
-        """
-        return ReciprocalLatticeVector(
-            phase=self.phase, xyz=np.matmul(rotation_matrix.T, self.data.T).T
-        )
-
     @property
     def structure_factor(self):
         r"""Kinematical structure factors :math:`F`.


### PR DESCRIPTION
#### Description of the change
Removes `ReciprocalLatticeVector.rotate_from_matrix`, and "manually" rotate instead where it was used

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [] Clean code style by [running black](https://diffsims.readthedocs.io/en/latest/contributing.html#get-the-style-right) (some unrelated files were formatted when I ran black)



#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the
      unreleased section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `credits` in `diffsims/release_info.py` and
      in `.zenodo.json`.